### PR TITLE
Platform Name Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In this version, I have made some changes from the older version. Mainly the plu
 
     "platforms": [
       {
-        "platform": "Particle",
+        "platform": "ParticleIO",
         "name": "Particle Devices",
         "access_token": "<<access token>>",
         "cloud_url": "https://api.particle.io/v1/devices/",


### PR DESCRIPTION
Was getting an exception when using `"platform": "Particle"`. Changed it to `ParticleIO` to get the configs to work.

Exception Message:
```
/usr/lib/node_modules/homebridge/lib/api.js:119
      throw new Error("The requested platform '" + name + "' was not registered by any plugin.");
      ^

Error: The requested platform 'Particle' was not registered by any plugin.
    at API.platform (/usr/lib/node_modules/homebridge/lib/api.js:119:13)
    at Server._loadPlatforms (/usr/lib/node_modules/homebridge/lib/server.js:284:45)
    at Server.run (/usr/lib/node_modules/homebridge/lib/server.js:80:36)
    at module.exports (/usr/lib/node_modules/homebridge/lib/cli.js:40:10)
    at Object.<anonymous> (/usr/lib/node_modules/homebridge/bin/homebridge:17:22)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```