### PR TITLE
Add accessory_id argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ In this version, I have made some changes from the older version. Mainly the plu
             "type": "lightbulb",
             "device_id": "<<device id>>",
             "function_name": "onoff",
-            "args": "1={STATE}"
+            "args": "1={STATE}",
+            "accessory_id": 1
           },
           {
             "name": "Kitchen Temperature",
@@ -69,4 +70,10 @@ The `devices` array contains all the accessories. You can see the accessory obje
  - **device_id** - Device ID of the Particle Device (Core, Photon or Electron). It is defined in accessory so that you can use different Particle Devices for different accessory.
  - **event_name** - The name of the event to listen for sensor value update. This is only valid if the accessory is a sensor (i.e. currently `temperaturesensor` or `humiditysensor`). The plugin listens for events published from a Particle Device (using `Particle.publish`). The device firmware should publish the sensor values as a raw number.
  - **function_name** - The name of the function that will be called when an action is triggered via HomeKit. This is only valid if the accessory is an actor (i.e. currently only `lightbulb`).
+ - **accessory_id** - The `accessory_id` may be used in order to allow for 2 accessories of the same type to be used with the same particle board.
 
+Each actor accessory type has a respective function it calls.
+ - **Switch** - `power`
+ - **Lightbulb** - `power`
+ - **DimmableLightbulb** - `brightness`
+ - **ColorLightbulb** - `hue` `saturation`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-particle-io",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Particle plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/sample-config.json
+++ b/sample-config.json
@@ -27,7 +27,8 @@
           "type": "lightbulb",
           "device_id": "<<device id>>",
           "function_name": "onoff",
-          "args": "1={STATE}"
+          "args": "1={STATE}",
+          "accessory_id": 1
         },
         {
           "name": "Kitchen Temperature",

--- a/src/ActorAccessory.js
+++ b/src/ActorAccessory.js
@@ -6,6 +6,7 @@ class ActorAccessory extends Accessory {
   constructor(log, url, accessToken, device, homebridge, ServiceType, CharacteristicType) {
     super(log, url, accessToken, device, homebridge, ServiceType, CharacteristicType);
 
+    this.accessoryId = device.accessory_id;
     this.actorService = new ServiceType(this.name);
     this.actorService.getCharacteristic(CharacteristicType)
                      .on('set', this.setState.bind(this))
@@ -16,10 +17,11 @@ class ActorAccessory extends Accessory {
 
   callParticleFunction(functionName, arg, callback, outputRAW) {
     const url = `${this.url}${this.deviceId}/${functionName}`;
-    this.log('Calling function: "', url, '" with arg: ', arg);
+    const allArgs = this.accessory_id != null ? `${arg}accessory_id=${this.accessory_id}` : arg;
+    this.log('Calling function: "', url, '" with args: ', allArgs);
     const form = {
       access_token: this.accessToken,
-      arg
+      allArgs
     };
     if (outputRAW) {
       form.format = 'raw';


### PR DESCRIPTION
This PR allows accessories of the same type to be used on the same particle board by. specifying an `accessory_id` 

This should satisfy #13 