### PR TITLE
Fix function_name for actor accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ The `devices` array contains all the accessories. You can see the accessory obje
  - **type** - Type of the accessory. As of now, the plugin supports 3 types: `lightbulb`, `temperaturesensor` and `humiditysensor`.
  - **device_id** - Device ID of the Particle Device (Core, Photon or Electron). It is defined in accessory so that you can use different Particle Devices for different accessory.
  - **event_name** - The name of the event to listen for sensor value update. This is only valid if the accessory is a sensor (i.e. currently `temperaturesensor` or `humiditysensor`). The plugin listens for events published from a Particle Device (using `Particle.publish`). The device firmware should publish the sensor values as a raw number.
- - **function_name** - The name of the function that will be called when an action is triggered via HomeKit. If there is no function provided, the default `power` will be used. This is only valid if the accessory is an actor (i.e. `lightbulb` or `switchaccessory`).
+ - **function_name** - The name of the particle function that will be called when an action is triggered via HomeKit. If there is no function provided, the default `power` will be used. This is only valid if the accessory is an actor (i.e. `lightbulb` or `switchaccessory`).
 

--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ The `devices` array contains all the accessories. You can see the accessory obje
  - **type** - Type of the accessory. As of now, the plugin supports 3 types: `lightbulb`, `temperaturesensor` and `humiditysensor`.
  - **device_id** - Device ID of the Particle Device (Core, Photon or Electron). It is defined in accessory so that you can use different Particle Devices for different accessory.
  - **event_name** - The name of the event to listen for sensor value update. This is only valid if the accessory is a sensor (i.e. currently `temperaturesensor` or `humiditysensor`). The plugin listens for events published from a Particle Device (using `Particle.publish`). The device firmware should publish the sensor values as a raw number.
- - **function_name** - The name of the function that will be called when an action is triggered via HomeKit. This is only valid if the accessory is an actor (i.e. currently only `lightbulb`).
+ - **function_name** - The name of the function that will be called when an action is triggered via HomeKit. If there is no function provided, the default `power` will be used. This is only valid if the accessory is an actor (i.e. `lightbulb` or `switchaccessory`).
 

--- a/src/ActorAccessory.js
+++ b/src/ActorAccessory.js
@@ -48,7 +48,7 @@ class ActorAccessory extends Accessory {
 
   setState(value, callback) {
     this.value = value;
-    this.callParticleFunction(this.functionName, value, (error, response, body) => this.callbackHelper(error, response, body, callback), true);
+    this.callParticleFunction(this.function_name, value, (error, response, body) => this.callbackHelper(error, response, body, callback), true);
   }
 
   callbackHelper(error, response, body, callback) {

--- a/src/ActorAccessory.js
+++ b/src/ActorAccessory.js
@@ -6,6 +6,7 @@ class ActorAccessory extends Accessory {
   constructor(log, url, accessToken, device, homebridge, ServiceType, CharacteristicType) {
     super(log, url, accessToken, device, homebridge, ServiceType, CharacteristicType);
 
+    this.function_name = !device.function_name ? 'power' : device.function_name;
     this.actorService = new ServiceType(this.name);
     this.actorService.getCharacteristic(CharacteristicType)
                      .on('set', this.setState.bind(this))
@@ -34,7 +35,7 @@ class ActorAccessory extends Accessory {
   }
 
   getState(callback) {
-    this.callParticleFunction("power", '?', (error, response, body) => {
+    this.callParticleFunction(this.function_name, '?', (error, response, body) => {
       this.value = parseInt(body);
       try {
         callback(null, this.value);
@@ -45,9 +46,9 @@ class ActorAccessory extends Accessory {
     true);
   }
 
-  setState(functionName, value, callback) {
+  setState(value, callback) {
     this.value = value;
-    this.callParticleFunction(functionName, value, (error, response, body) => this.callbackHelper(error, response, body, callback), true);
+    this.callParticleFunction(this.functionName, value, (error, response, body) => this.callbackHelper(error, response, body, callback), true);
   }
 
   callbackHelper(error, response, body, callback) {

--- a/src/LightbulbAccessory.js
+++ b/src/LightbulbAccessory.js
@@ -9,7 +9,7 @@ class LightbulbAccessory extends ActorAccessory {
   }
 
   setState(value, callback) {
-    super.setState("power", value ? '1' : '0', callback);
+    super.setState(value ? '1' : '0', callback);
   }
 
 }

--- a/test/ActorAccessory-test.js
+++ b/test/ActorAccessory-test.js
@@ -50,7 +50,7 @@ describe('ActorAccessory.js', () => {
     it('should send value', () => {
       sinon.stub(request, 'post');
       const value = 17;
-      accessory.setState("testFunctionName", value, () => {});
+      accessory.setState(value, () => {});
 
       expect(request.post).to.have.been.calledOnce;
       expect(request.post).to.have.been.calledWith(
@@ -71,7 +71,7 @@ describe('ActorAccessory.js', () => {
       sinon.stub(request, 'post', () => { accessory.callbackHelper(undefined, 200, 'body', spy); });
 
       const value = 17;
-      accessory.setState("testFunctionName", value, spy);
+      accessory.setState(value, spy);
 
       expect(spy).to.have.been.calledOnce;
       expect(spy.lastCall.args).to.have.length(0);
@@ -83,7 +83,7 @@ describe('ActorAccessory.js', () => {
       sinon.stub(request, 'post', () => { accessory.callbackHelper('some error', 200, 'body', spy); });
 
       const value = 17;
-      accessory.setState("testFunctionName", value, spy);
+      accessory.setState(value, spy);
 
       expect(spy).to.have.been.calledOnce;
       expect(spy.lastCall.args).to.have.length(1);

--- a/test/dummyConfig.js
+++ b/test/dummyConfig.js
@@ -7,7 +7,8 @@ const dummyConfig = {
     {
       name: 'Bedroom Light',
       type: 'lightbulb',
-      device_id: 'abcdef1234567890'
+      device_id: 'abcdef1234567890',
+      function_name: 'testFunctionName'
     },
     {
       name: 'Kitchen Light',


### PR DESCRIPTION
Call the custom function if provided, or use 'power' as default.