### PR TITLE
Support for custom format in event data

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ In this version, I have made some changes from the older version. Mainly the plu
             "name": "Kitchen Temperature",
             "type": "temperaturesensor",
             "device_id": "<<device id>>",
-            "event_name": "tvalue"
+            "event_name": "tvalue",
+            "split_character": ":"
           }
         ]
       }
@@ -70,3 +71,10 @@ The `devices` array contains all the accessories. You can see the accessory obje
  - **event_name** - The name of the event to listen for sensor value update. This is only valid if the accessory is a sensor (i.e. currently `temperaturesensor` or `humiditysensor`). The plugin listens for events published from a Particle Device (using `Particle.publish`). The device firmware should publish the sensor values as a raw number.
  - **function_name** - The name of the function that will be called when an action is triggered via HomeKit. This is only valid if the accessory is an actor (i.e. currently only `lightbulb`).
 
+**Particle Event Data Format**
+-------------------------------------
+By default it expects the event data as "key=value".
+```
+Particle.publish("tvalue", "temperature=20.7")
+```
+In order to parse JSON format, a custom `split_character` can be configured.

--- a/src/SensorAccessory.js
+++ b/src/SensorAccessory.js
@@ -8,6 +8,7 @@ class SensorAccessory extends Accessory {
     this.eventName = device.event_name;
     this.key = device.key;
     this.unit = null;
+    this.split_character = !device.split_character ? '=' : device.split_character;
 
     this.eventUrl = `${this.url}${this.deviceId}/events/${this.eventName}?access_token=${this.accessToken}`;
     this.log('Listening for events from:', this.eventUrl);
@@ -30,7 +31,7 @@ class SensorAccessory extends Accessory {
 
   processEventData(e) {
     const data = JSON.parse(e.data);
-    const result = this.key ? data.data.split('=')[1] : data.data;
+    const result = this.key ? data.data.split(this.split_character)[1] : data.data;
 
     if (this.services.length < 2) {
       return;

--- a/test/SensorAccessory-test.js
+++ b/test/SensorAccessory-test.js
@@ -33,6 +33,7 @@ describe('SensorAccessory.js', () => {
       accessory.eventUrl.should.be.equal(
         'https://some.random.url.com/1234567890abcdef/events/humidity?access_token=MY_top_SECRET_access_TOKEN'
       );
+      accessory.split_character.should.be.equal(device.split_character);
 
       accessory.services.should.have.length(2);
       accessory.services[1].should.be.an.instanceOf(Service.HumiditySensor);

--- a/test/dummyConfig.js
+++ b/test/dummyConfig.js
@@ -24,7 +24,8 @@ const dummyConfig = {
       name: 'Kitchen Humidity',
       type: 'humiditysensor',
       device_id: '1234567890abcdef',
-      event_name: 'humidity'
+      event_name: 'humidity',
+      split_character: ':'
     },
     {
       name: 'Kitchen Light Sensor',


### PR DESCRIPTION
Default '=' will be used if no split_character is provided.
Note: JSON has ':' as split character for key/value pairs.